### PR TITLE
Add functioning API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "Howe, Lombard, Messineo, Hamel",
   "license": "MIT",
   "dependencies": {
+    "axios": "0.15.3",
     "dotenv-webpack": "1.4.3",
     "object-assign": "4.1.0",
     "react": "15.4.1",

--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-const key = process.env.key;
 
 export default class Main extends Component {
   constructor(props) {
@@ -7,18 +6,19 @@ export default class Main extends Component {
   }
 
   componentDidMount() {
-    fetch(`https://maps.googleapis.com/maps/api/place/textsearch/json?query=11109&key=${key}&type=restaurant&opennow=true`, {
-        method: 'GET'
-      })
-    .then((results) => {
-      results
-      .json()
+    fetch(`http://localhost:8000/restaurants/zip/11103`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+    .then(r => r.json()
       .then((data) => {
         console.log(data);
       })
-    })
+    )
+    .catch((err) => console.log(err));
   }
-
 
   render() {
     return(

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -10,7 +10,6 @@
     This is an example of how to add features to index.html for only one environment.
     To track JavaScript errors via TrackJS, sign up for a free trial at TrackJS.com and enter your token in /webpack.config.prod.js on line 55.
    -->
-
   <% if (htmlWebpackPlugin.options.trackJSToken) { %>
   <script>window._trackJs = {token: '<%= htmlWebpackPlugin.options.trackJSToken %>'};</script>
   <script src="https://d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js"></script>


### PR DESCRIPTION
Fetch calls to Google Places now work using server-side proxy.

Look to Express-Decidr for corresponding updates.

"Mr. Hammond, the phones are working."
